### PR TITLE
feature/add fibre information

### DIFF
--- a/src/pykoala/data_container.py
+++ b/src/pykoala/data_container.py
@@ -638,11 +638,39 @@ class RSS(SpectraContainer):
     def rss_variance(self, value):
         self.variance = value
 
+    @property
+    def fibre_diameter(self):
+        """Angular diameter of the RSS fibres."""
+        return self._fibre_diameter
+    
+    @fibre_diameter.setter
+    def fibre_diameter(self, value):
+        assert isinstance(value, u.Quantity) or value is None, (
+            "Fibre diameter must be a astropy.units.Quantity")
+        self._fibre_diameter = value
+
+    @property
+    def sky_fibres(self):
+        """Indices of the RSS sky fibres."""
+        return self._sky_fibres
+    
+    @sky_fibres.setter
+    def sky_fibres(self, value):
+        self._sky_fibres = value
+
+    @property
+    def science_fibres(self):
+        """Indices of fibres with a science target."""
+        return np.delete(np.arange(self.intensity.shape[0]), self.sky_fibres)
+
     def __init__(self, **kwargs):
         assert ('wavelength' in kwargs)
         assert ('intensity' in kwargs)
         if "logger" not in kwargs:
             kwargs['logger'] = "pykoala.rss"
+
+        self.fibre_diameter = kwargs.get("fibre_diameter", None)
+        self.sky_fibres = kwargs.get("sky_fibres", [])
         super().__init__(**kwargs)
 
     def get_centre_of_mass(self, wavelength_step=1, stat=np.nanmedian, power=1.0):

--- a/src/pykoala/instruments/koala_ifu.py
+++ b/src/pykoala/instruments/koala_ifu.py
@@ -10,6 +10,7 @@ import os
 # =============================================================================
 # Astropy and associated packages
 # =============================================================================
+from astropy import units as u
 from astropy.io import fits
 from astropy.wcs import WCS
 # =============================================================================
@@ -156,7 +157,8 @@ def read_rss(file_path,
                variance=variance,
                wavelength=wavelength,
                info=info,
-               header=header)
+               header=header,
+               fibre_diameter=1.25 * u.arcsec)
     rss.history('read', ' '.join(['- RSS read from ', file_name]))
     return rss
 


### PR DESCRIPTION
This PR includes three new attributes on the RSS class:
- fibre_diameter: the diameter of the fibres, necessary in some correction modules.
- sky_fibres: list of fibres that correspond to sky fibres.
- science_fibres: a handy attribute that provides the fibres used for sciene.